### PR TITLE
Version of Jenkins fixed to 2.164.3

### DIFF
--- a/Subutai.json
+++ b/Subutai.json
@@ -1,7 +1,7 @@
 {
     "name": "${environmentName}",
     "description": "Jenkins",
-    "version": "2.164.1",
+    "version": "2.164.3",
     "author": "https://github.com/tasankulov",
     "containers": [{
         "hostname": "${webContainerName}",

--- a/main.yml
+++ b/main.yml
@@ -1,3 +1,4 @@
+# Ansible Playbook for Subutai Jenkins Blueprint
 ---
 
 - hosts: jenkins
@@ -28,11 +29,15 @@
         state: present
         filename: jenkins.list
 
-    - name: Install jenkins
-      apt: 
-        name: jenkins
-        state: present
-        update_cache: yes
+#    - name: Install jenkins
+#      apt: 
+#        name: jenkins
+#        state: present
+#        update_cache: yes
+
+    - name: Install a jenkins 2.164.3.deb package from the internet.
+      apt:
+        deb: https://pkg.jenkins.io/debian-stable/binary/jenkins_2.164.3_all.deb
 
     - name: Wait until the file "initialAdminPassword" is present before continuing
       wait_for:


### PR DESCRIPTION
- New version of Jenkins added some security features due to that requiring new version of ansible to build it.
Links to the problem:
- https://github.com/ansible/ansible/issues/61712
- https://jenkins.io/doc/upgrade-guide/2.176/#SECURITY-626